### PR TITLE
GUI support of Launder-Sharma turbulence model for realize v6.0

### DIFF
--- a/bin/model/TurbulenceModel.py
+++ b/bin/model/TurbulenceModel.py
@@ -75,6 +75,7 @@ class TurbulenceModel(Variables, Model):
                             'mixing_length',
                             'k-epsilon',
                             'k-epsilon-PL',
+			    'Launder-Sharma',
                             'Rij-epsilon',
                             'Rij-SSG',
                             'Rij-EBRSM',
@@ -215,7 +216,7 @@ class TurbulenceModel(Variables, Model):
             self.__removeVariablesAndProperties([], 'smagorinsky_constant^2')
             self.node_turb.xmlRemoveChild('wall_function')
 
-        elif model_turb in ('k-epsilon', 'k-epsilon-PL'):
+        elif model_turb in ('k-epsilon', 'k-epsilon-PL', 'Launder-Sharma'):
             lst = ('k', 'epsilon')
             for v in lst:
                 self.setNewVariable(self.node_turb, v, label=v)
@@ -480,7 +481,7 @@ class TurbulenceModel(Variables, Model):
         model = self.getTurbulenceModel()
         nodeList = []
 
-        if model in ('k-epsilon','k-epsilon-PL'):
+        if model in ('k-epsilon','k-epsilon-PL','Launder-Sharma'):
             nodeList.append(self.node_turb.xmlGetNode('variable', name='k'))
             nodeList.append(self.node_turb.xmlGetNode('variable', name='epsilon'))
         elif model in ('Rij-epsilon', 'Rij-SSG', 'Rij-EBRSM'):
@@ -577,6 +578,23 @@ class TurbulenceModelTestCase(ModelTest):
               </turbulence>'''
         assert mdl.node_turb == self.xmlNodeFromString(doc),\
             'Could not set the linear production k-epsilon turbulence model'
+    
+    def checkSetLaunderSharma(self):
+        """Check whether the Launder-Sharma k-epsilon turbulence model could be set"""
+        mdl = TurbulenceModel(self.case)
+        mdl.setTurbulenceModel('Launder-Sharma')
+        doc ='''<turbulence model="Launder-Sharma">
+                <variable label="TurbEner" name="k"/>
+                <variable label="Dissip" name="epsilon"/>
+                <property label="TurbVisc" name="turbulent_viscosity"/>
+                <initialization choice="reference_velocity">
+                  <reference_velocity>1</reference_velocity>
+                </initialization>
+               </turbulence>'''
+
+        assert mdl.node_turb == self.xmlNodeFromString(doc),\
+            'Could not set the Launder-Sharma k-epsilon turbulence model'
+	    
 
     def checkSetRijepsilon(self):
         """Check whether the Rij-epsilon turbulence model could be set"""

--- a/gui/Pages/TurbulenceView.py
+++ b/gui/Pages/TurbulenceView.py
@@ -84,6 +84,8 @@ class TurbulenceAdvancedOptionsDialogView(QDialog, Ui_TurbulenceAdvancedOptionsD
 
         if default['model'] in ('k-epsilon', 'k-epsilon-PL'):
             title = self.tr("Options for k-epsilon model")
+	elif default['model'] in ('Launder-Sharma'):
+            title = self.tr("Options for Launder-Sharma k-epsilon model")
         elif default['model'] in ('Rij-epsilon', 'Rij-SSG', 'Rij-EBRSM'):
             title = self.tr("Options for Rij-epsilon model")
         elif default['model'] == 'k-omega-SST':
@@ -210,6 +212,7 @@ class TurbulenceView(QWidget, Ui_TurbulenceForm):
         self.modelTurbModel.addItem(self.tr("Mixing length"), "mixing_length")
         self.modelTurbModel.addItem(self.tr("k-epsilon"), "k-epsilon")
         self.modelTurbModel.addItem(self.tr("k-epsilon Linear Production"), "k-epsilon-PL")
+	self.modelTurbModel.addItem(self.tr("Launder-Sharma"), "Launder-Sharma")
         self.modelTurbModel.addItem(self.tr("Rij-epsilon LRR"), "Rij-epsilon")
         self.modelTurbModel.addItem(self.tr("Rij-epsilon SSG"), "Rij-SSG")
         self.modelTurbModel.addItem(self.tr("Rij-epsilon EBRSM"), "Rij-EBRSM")

--- a/src/gui/cs_gui.c
+++ b/src/gui/cs_gui.c
@@ -1606,6 +1606,11 @@ void cs_gui_turb_model(void)
     cs_gui_node_get_child_int(tn_t, "wall_function", &iwallf);
     cs_gui_node_get_child_status_int(tn_t, "gravity_terms", &(rans_mdl->igrake));
   }
+  else if (cs_gui_strcmp(model, "Launder-Sharma")) {
+    turb_mdl->iturb = 22;
+    cs_gui_node_get_child_int(tn_t, "wall_function", &iwallf);
+    cs_gui_node_get_child_status_int(tn_t, "gravity_terms", &(rans_mdl->igrake));
+  }
   else if (cs_gui_strcmp(model, "Rij-epsilon")) {
     turb_mdl->iturb = 30;
     cs_gui_node_get_child_int(tn_t, "wall_function", &iwallf);

--- a/src/gui/cs_gui_boundary_conditions.c
+++ b/src/gui/cs_gui_boundary_conditions.c
@@ -2156,7 +2156,8 @@ void CS_PROCF (uiclim, UICLIM)(const int  *idarcy,
             return;
 
           if (   cs_gui_strcmp(model, "k-epsilon")
-              || cs_gui_strcmp(model, "k-epsilon-PL")) {
+              || cs_gui_strcmp(model, "k-epsilon-PL")
+	      || cs_gui_strcmp(model, "Launder-Sharma")) {
 
             cs_real_t *new_vals = cs_meg_boundary_function("turbulence_ke",
                                                            "formula",


### PR DESCRIPTION
I have implemented option of Launder-Sharma model to GUI. Looks like it works. There is questions what kind of wall-functions is possible to use with that model. I implemented the same wall functions options as for k-epsilon models, but maybe it should be just two options: 1) wallfunction "all y+" . 2) "no wall function". I think it would be easy to fix.