### PR TITLE
Make configure portable

### DIFF
--- a/m4/cs_blas.m4
+++ b/m4/cs_blas.m4
@@ -346,7 +346,7 @@ if test "x$with_blas" != "xno" ; then
     if test "x$with_blas_libs" != "x" ; then
       BLAS_LIBS="$with_blas_libs"
     else
-      BLAS_LIBS="-lblas"
+      BLAS_LIBS="-lcblas -lblas"
     fi
 
     CPPFLAGS="${saved_CPPFLAGS} ${BLAS_CPPFLAGS}"

--- a/salome/m4/cs_omniorb.m4
+++ b/salome/m4/cs_omniorb.m4
@@ -219,7 +219,7 @@ then
   OMNIORB_IDLPYFLAGS_1='-bpython -nf '
   OMNIORB_IDLPYFLAGS_2=" -I${OMNIORB_ROOT}/idl"
   OMNIORB_IDLPYFLAGS=${OMNIORB_IDLPYFLAGS_1}${OMNIORB_IDLPYFLAGS_2}
-  for p in `cut -d: -f 1- --output-delimiter=$'\n' <<<"$PYTHONPATH"`; do
+  for p in `echo "$PYTHONPATH" | tr ':' $'\n'`; do
     if test -f $p/omniidl_be/python.py; then
       OMNIORB_IDLPYFLAGS="${OMNIORB_IDLPYFLAGS} -p ${p}"
     fi


### PR DESCRIPTION
Here strings are a bashism, and cut´s --output-delimiter a linuxism: replace them.