### PR TITLE
Execute sbin/bootstrap when user didn't execute it in install script

### DIFF
--- a/install_saturne.py
+++ b/install_saturne.py
@@ -542,6 +542,10 @@ class Setup:
 
         p = self.packages['code_saturne']
 
+        if not os.path.exists(os.path.join(self.top_srcdir, 'configure')):
+            sys.stdout.write(f"Executing {os.path.join(self.top_srcdir, 'sbin/bootstrap')}\n")
+            subprocess.Popen('./sbin/bootstrap', cwd=self.top_srcdir)
+
         p.set_version_from_configure(os.path.join(self.top_srcdir, 'configure'))
 
         p.use = 'yes'


### PR DESCRIPTION
I had the same issue as #59 so made this little modification.