### PR TITLE
FLAGS Error Scotch install fails with semi-automatic installation

### DIFF
--- a/install_saturne.py
+++ b/install_saturne.py
@@ -387,7 +387,7 @@ class Package:
             fdr = open('Make.inc/Makefile.inc.x86-64_pc_linux2')
         fd = open('Makefile.inc','w')
 
-        re_thread = re.compile('-DSCOTCH_PTHREAD')
+        re_thread = re.compile('-DSCOTCH_PTHREAD ')
         re_intsize32 = re.compile('-DINTSIZE32')
         re_intsize64 = re.compile('-DINTSIZE64')
         re_idxsize64 = re.compile('-DIDXSIZE64')
@@ -397,7 +397,7 @@ class Package:
             if line[0:3] in ['CCS', 'CCP', 'CCD']:
                 i1 = line.find('=')
                 line = line[0:i1] + '= ' + self.cc + '\n'
-            line = re.sub(re_thread, '', line)
+            line = re.sub(re_thread, ' ', line)
             line = re.sub(re_intsize32, '', line)
             line = re.sub(re_intsize64, '', line)
             line = re.sub(re_idxsize64, '-DIDXSIZE64 -DINTSIZE64', line)


### PR DESCRIPTION
In install_saturne.py when installing PT-Scotch it fails due to a wrong regex substitution.
In the makefile it runs the following command : 
`/opt/openmpi/bin/mpicc -O3 -fPIC -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_PTHREAD -DCOMMON_PTHREAD_AFFINITY_LINUX -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_MPI_ASYNC_COLL  _MPI  -DSCOTCH_RENAME -Drestrict=__restrict -DIDXSIZE64 -DINTSIZE64 -shared -fPIC -c arch.c -o arch.o -DSCOTCH_VERSION_NUM=7 -DSCOTCH_RELEASE_NUM=0 -DSCOTCH_PATCHLEVEL_NUM=3
`
So it fails because the `_MPI` does not correspond to any option.

This is due because in the original command `_MPI` correspond to `-DSCOTCH_PTHREAD -DSCOTCH_PTHREAD_MPI` and in install_saturne.py line 390 and 400 -DSCOTCH_PTHREAD is replaced by '' so I believe that to fix this problem we can simply sub '-DSCOTCH_PTHREAD ' by ' ' adding 2 times one space can fix the problem.