### PR TITLE
Fix detection of turbulent variables in GUI for default equation parameters

### DIFF
--- a/python/code_saturne/model/NumericalParamEquationModelNeptune.py
+++ b/python/code_saturne/model/NumericalParamEquationModelNeptune.py
@@ -131,7 +131,8 @@ class NumericalParamEquatModel(Variables, Model):
         """
         Return : 1 if name of node is a turbulence variable, 0 if not
         """
-        if node and node['name'] in TurbulenceModelsDescription.turbulenceVariables['all'] :
+        if node and any(node['name'].startswith(prefix) for prefix 
+                        in TurbulenceModelsDescription.turbulenceVariables['all']) :
             return 1
         else:
             return 0


### PR DESCRIPTION
In neptune_cfd mode, some turbulent variables are not detected as such. At IMFT this is in particular the case for `covariance_qfp` whose default scheme is SOLU whilst it should be set to the `order_scheme_pressure_turbulence` scheme (UPWIND) like for other turbulent variables:

![image](https://github.com/code-saturne/code_saturne/assets/36629489/a919d54b-2647-4dda-be12-b4becda37532)

The issue comes from the XML node name which in this case is `covariance_qfp_1` and not just `covariance_qfp`.

I propose a fix to the `_isTurbulenceVariable` method where instead of checking for strict equality between the XML node name and the list of expected names for turbulent variables, I treat these expected names as possible prefixes and check if the names starts with any of these prefixes.

This correctly fixes the issue as now all turbulent variables have the expected scheme.