### PR TITLE
Fix TypeError in QTimer.start() when loading state with `trackvcg`

### DIFF
--- a/python/code_saturne/gui/trackcvg/MainView.py
+++ b/python/code_saturne/gui/trackcvg/MainView.py
@@ -1214,7 +1214,7 @@ class MainView(object):
                         itt.status     = nn.getAttribute('status')
                         itt.subplot_id = int(nn.getAttribute('subplot_id'))
             self.lineEditTime.setText(str(self.timeRefresh))
-            self.timer.start(self.timeRefresh * 1000)
+            self.timer.start(int(self.timeRefresh * 1000))
             self.spinBox.setValue(int(self.subplotNumber))
 
 


### PR DESCRIPTION
When loading a state using `code_saturne trackvcg` the program crashes because `self.timeRefresh * 1000` produces a `float`, but `QTimer.start()` strictly requires an `int`. Convert the value to `int` before passing it on.