### PR TITLE
[GUI] Fix convection scheme selection for compressible model

### DIFF
--- a/python/code_saturne/gui/case/NumericalParamEquationView.py
+++ b/python/code_saturne/gui/case/NumericalParamEquationView.py
@@ -53,6 +53,7 @@ from code_saturne.gui.base.QtPage import from_qvariant
 from code_saturne.gui.case.NumericalParamEquationForm import Ui_NumericalParamEquationForm
 from code_saturne.model.NumericalParamEquationModel import NumericalParamEquationModel
 from code_saturne.model.TurbulenceModel import TurbulenceModel
+from code_saturne.model.CompressibleModel import CompressibleModel
 
 #-------------------------------------------------------------------------------
 # log config
@@ -535,6 +536,8 @@ class StandardItemModelScheme(QStandardItemModel):
         """
         QStandardItemModel.__init__(self)
         self.NPE = NPE
+        self.is_compressible = \
+            CompressibleModel(NPE.case).getCompressibleModel() != 'off'
         self.dataScheme = []
         # list of items to be disabled in the QTableView
         self.disabledItem = []
@@ -669,6 +672,10 @@ class StandardItemModelScheme(QStandardItemModel):
 
         if role == Qt.ItemDataRole.ToolTipRole:
             col = index.column()
+            if self.is_compressible and col in (1, 2, 3):
+                return self.tr(
+                    "Forced to first-order upwind for the compressible"
+                    " model (set in cs_cf_setup).")
             if col > 0 and col < 9:
                 return self.tooltips[col-1]
             elif col > 0:
@@ -676,8 +683,16 @@ class StandardItemModelScheme(QStandardItemModel):
 
         elif role == Qt.ItemDataRole.DisplayRole:
             if key == 'ischcv':
+                if self.is_compressible:
+                    return "Upwind"
                 return self.dicoM2V[dico[key]]
+            elif key == 'blencv':
+                if self.is_compressible:
+                    return 0.
+                return dico[key]
             elif key == 'isstpc':
+                if self.is_compressible:
+                    return ""
                 if self.dataScheme[row]['blencv'] > 0:
                     return self.dicoM2V_isstpc[dico[key]]
                 else:
@@ -730,9 +745,19 @@ class StandardItemModelScheme(QStandardItemModel):
 
         if column == 0:
             return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
-        elif column in (1, 2, 6):
+        elif column in (1, 2):
+            # For compressible flows, the convection scheme is forced
+            # to first-order upwind (blencv=0) in cs_cf_setup,
+            # so these columns are not editable.
+            if self.is_compressible:
+                return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
+            return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEditable
+        elif column == 6:
             return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEditable
         elif column == 3:
+            # For compressible flows, slope test is irrelevant (blencv=0)
+            if self.is_compressible:
+                return Qt.ItemFlag.NoItemFlags
             if self.dataScheme[row]['blencv'] > 0:
                 return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEditable
             else:
@@ -775,6 +800,11 @@ class StandardItemModelScheme(QStandardItemModel):
         row = index.row()
         column = index.column()
         name = self.dataScheme[row]['name']
+
+        # For compressible flows, scheme/blending/slope test are forced
+        # to upwind in cs_cf_setup and should not be modified here.
+        if self.is_compressible and column in (1, 2, 3):
+            return False
 
         # for Pressure, most fields are empty
         if column > 0 and str(value) in ['', 'None']:


### PR DESCRIPTION
## Summary

The convection scheme settings (scheme type, blending factor, slope test) in the Equation parameters → Scheme tab are fully editable when the compressible model is active. However, cs_cf_setup() unconditionally forces blencv = 0 (first-order upwind) for all variable fields, silently overriding any user selection. 

This patch detects the compressible model in StandardItemModelScheme and locks the affected columns:
 - Scheme column: displays "Upwind", not editable 
 - Blending factor column: displays 0.0, not editable
 - Slope test column: hidden (irrelevant when blencv = 0)
 - A tooltip explains the lock: "Forced to first-order upwind for the compressible model (set in cs_cf_setup)."

Other columns (flux reconstruction, RHS sweep reconstruction) remain editable as they are not overridden by cs_cf_setup().               
                                                                                                                                           
## Changes
 - Add is_compressible flag in StandardItemModelScheme.__init__() using CompressibleModel
 - Override data() display for scheme/blend/slope test columns when compressible is active
 - Override flags() to make these columns read-only
 - Short-circuit setData() for these columns to prevent writes                                                                            
                                                                                                                                           
## Test
Tested manually with:
- Compressible model active → Scheme and Blend columns are grayed out, show "Upwind" / 0.0, tooltip on hover
- Compressible model off → all columns editable as before 